### PR TITLE
Add ValidationException; use SWFResponseError for unrecognized errors

### DIFF
--- a/botoflow/swf_exceptions.py
+++ b/botoflow/swf_exceptions.py
@@ -102,9 +102,14 @@ class ThrottlingException(SWFResponseError):
     pass
 
 
+class ValidationException(SWFResponseError):
+    pass
+
+
 class InternalFailureError(SWFResponseError):
     """Raised when there's an internal SWF failure"""
     pass
+
 
 # SWF __type/fault string to botoflow exception mapping
 _swf_fault_exception = {
@@ -115,10 +120,11 @@ _swf_fault_exception = {
     'WorkflowExecutionAlreadyStartedFault': WorkflowExecutionAlreadyStartedError,
     'TypeDeprecatedFault': TypeDeprecatedError,
     'TypeAlreadyExistsFault': TypeAlreadyExistsError,
-    'cOperationNotPermittedFault': OperationNotPermittedError,
+    'OperationNotPermittedFault': OperationNotPermittedError,
     'UnknownResourceFault': UnknownResourceError,
     'SWFResponseError': SWFResponseError,
     'ThrottlingException': ThrottlingException,
+    'ValidationException': ValidationException,
     'UnrecognizedClientException': UnrecognizedClientException,
     'InternalFailure': InternalFailureError
 }
@@ -133,4 +139,4 @@ def swf_exception_wrapper():
         err_msg = err.response['Error'].get(
             'Message', 'No error message provided...')
 
-        raise _swf_fault_exception[err_type](err_msg)
+        raise _swf_fault_exception.get(err_type, SWFResponseError)(err_msg)

--- a/test/unit/test_swf_exceptions.py
+++ b/test/unit/test_swf_exceptions.py
@@ -1,0 +1,63 @@
+import pytest
+
+from botocore.exceptions import ClientError
+
+from botoflow import swf_exceptions
+
+
+def test_swf_exception_wrapper_with_no_exception():
+    with swf_exceptions.swf_exception_wrapper():
+        pass # nothing went wrong
+
+
+def test_swf_exception_wrapper_with_unknown_exception():
+    with pytest.raises(swf_exceptions.SWFResponseError) as exc:
+        with swf_exceptions.swf_exception_wrapper():
+            raise ClientError({'Error': {'Code': 'SomethingBrokeError', 'Message': 'Oops'}}, 'foobar')
+
+    assert str(exc.value) == "Oops"
+
+
+@pytest.mark.parametrize('code_key,expected_exception', [
+    ('DomainDeprecatedFault', swf_exceptions.DomainDeprecatedError),
+    ('DomainAlreadyExistsFault', swf_exceptions.DomainAlreadyExistsError),
+    ('DefaultUndefinedFault', swf_exceptions.DefaultUndefinedError),
+    ('LimitExceededFault', swf_exceptions.LimitExceededError),
+    ('WorkflowExecutionAlreadyStartedFault', swf_exceptions.WorkflowExecutionAlreadyStartedError),
+    ('TypeDeprecatedFault', swf_exceptions.TypeDeprecatedError),
+    ('TypeAlreadyExistsFault', swf_exceptions.TypeAlreadyExistsError),
+    ('OperationNotPermittedFault', swf_exceptions.OperationNotPermittedError),
+    ('UnknownResourceFault', swf_exceptions.UnknownResourceError),
+    ('SWFResponseError', swf_exceptions.SWFResponseError),
+    ('ThrottlingException', swf_exceptions.ThrottlingException),
+    ('ValidationException', swf_exceptions.ValidationException),
+    ('UnrecognizedClientException', swf_exceptions.UnrecognizedClientException),
+    ('InternalFailure', swf_exceptions.InternalFailureError),
+])
+def test_swf_exception_wrapper_with_known_exception(code_key, expected_exception):
+    with pytest.raises(expected_exception) as exc:
+        with swf_exceptions.swf_exception_wrapper():
+            raise ClientError({'Error': {'Code': code_key, 'Message': 'Oops'}}, 'foobar')
+
+    assert str(exc.value) == "Oops"
+
+
+def test_swf_exception_wrapper_with_no_error_response_details():
+    with pytest.raises(swf_exceptions.SWFResponseError) as exc:
+        with swf_exceptions.swf_exception_wrapper():
+            raise ClientError({'Error': {'Code': None, 'Message': None}}, 'foobar')
+
+
+def test_swf_exception_wrapper_with_malformed_code_key():
+    with pytest.raises(swf_exceptions.SWFResponseError) as exc:
+        with swf_exceptions.swf_exception_wrapper():
+            raise ClientError({'Error': {'Code': (123, "this is not a key"), 'Message': None}}, 'foobar')
+
+
+def test_swf_exception_wrapper_with_non_client_error():
+    exception = RuntimeError("Not handled by swf_exception_wrapper")
+    with pytest.raises(RuntimeError) as exc:
+        with swf_exceptions.swf_exception_wrapper():
+            raise exception
+
+    assert exc.value == exception


### PR DESCRIPTION
Also, remove what looks like a spurious 'c' for OperationNotPermittedFault.