### PR TITLE
Set data_converter for activity types

### DIFF
--- a/botoflow/decorators.py
+++ b/botoflow/decorators.py
@@ -197,10 +197,11 @@ def activities(task_list=USE_WORKER_TASK_LIST,
                 if hasattr(_func, 'swf_options'):  # decorated
                     _set_swf_options(_func, 'activity_name_prefix',
                                      activity_name_prefix)
-                    _set_swf_options(_func, 'data_converter',
-                                     data_converter)
 
                     activity_type = _func.swf_options['activity_type']
+
+                    if data_converter is not None:
+                        activity_type.data_converter = data_converter
 
                     activity_type._set_activities_value(
                         'task_list', task_list)

--- a/test/unit/test_decorators.py
+++ b/test/unit/test_decorators.py
@@ -1,0 +1,25 @@
+from botoflow import activities, activity
+from botoflow.data_converter.json_data_converter import JSONDataConverter
+
+
+def test_activities_decorator_adds_data_converter():
+    class MyDataConverter(object):
+        pass
+
+    @activities(data_converter=MyDataConverter())
+    class ActivitiesWithCustomDataConverter(object):
+        @activity(None)
+        def foobar(self):
+            pass
+
+    assert isinstance(ActivitiesWithCustomDataConverter().foobar.swf_options['activity_type'].data_converter, MyDataConverter)
+
+
+def test_activities_decorator_uses_default_data_converter():
+    @activities()
+    class ActivitiesWithDefaultDataConverter(object):
+        @activity(None)
+        def foobar(self):
+            pass
+
+    assert isinstance(ActivitiesWithDefaultDataConverter().foobar.swf_options['activity_type'].data_converter, JSONDataConverter)


### PR DESCRIPTION
Prior to this change the data converter was being set in the swf_options
attached to the function and not in the ActivityType where it is looked
for. This meant that the default data converter was always used.