### PR TITLE
[Issue 10] Let Attribute Errors allow a check for __exc

### DIFF
--- a/botoflow/data_converter/json_data_converter.py
+++ b/botoflow/data_converter/json_data_converter.py
@@ -205,7 +205,7 @@ def _flow_obj_decoder(dct):
         cls = getattr(module, attr_name)
 
     # if an import error is raised
-    except ImportError:
+    except (ImportError, AttributeError):
         # try and rescue objects with exception information by bundling them
         # into a ImportError
         if '__exc' in dct:

--- a/test/unit/data_converter/test_json_data_converter.py
+++ b/test/unit/data_converter/test_json_data_converter.py
@@ -175,6 +175,15 @@ def test_unimportable_exception(serde):
     assert 'unknown_module.MyUnknownException: some error message' == r.message
     assert 'someparam' == r.other
 
+
+def test_importable_module_but_no_exception(serde):
+    raw = '{"__obj":["botoflow.utils:MyUnknownException",{"other":"someparam"}],"__exc":[["some error message"],"some error message"]}'
+    r = serde.loads(raw)
+    assert isinstance(r, ImportError)
+    assert 'botoflow.utils.MyUnknownException: some error message' == r.message
+    assert 'someparam' == r.other
+
+
 def test_unimportable_object(serde):
     raw = '{"__obj":["unknown_module:MyUnknownObject",{"other":"someparam"}]}'
     with pytest.raises(ImportError):


### PR DESCRIPTION
When decoding objects, if the object is not present in the module, allow decoding to continue just as if the module didn't exist

This is based on the assumption that `module = __import__(module_name, globals(), locals(), [attr_name], 0)
        cls = getattr(module, attr_name)` was expected to give an `ImportError` when the module did not contain the attribute referred to by `attr_name`, like the `from-import` statement. But apparently the `__import__` function does not give an error in this case.